### PR TITLE
Ensure that blocking sizes can work out (fixes GH-23)

### DIFF
--- a/include/qphix/geometry.h
+++ b/include/qphix/geometry.h
@@ -111,6 +111,12 @@ namespace QPhiX {
 			Nz_ = latt_size[2];
 			Nt_ = latt_size[3];
 			Nxh_ = Nx_/2;
+
+      // Ensure that blocking is possible.
+      if (Ny_ % By_ != 0 || Nz_ % Bz_ != 0) {
+        throw std::domain_error("Local lattice size Ny must be divisible by "
+                                "blocking length By. Same for Nz and Bz.");
+      }
       
 			nvecs_ = Nxh()/ S;
 			if (Nxh()% S != 0) nvecs_++;


### PR DESCRIPTION
Every QPhiX operation has to construct a `Geometry` object at some time.
Therefore the check seems to be best placed there.

At startup, there will be an uncaught exception that causes the calling
program (Chroma, tmLQCD) to crash right away. Currently Chroma will
crash because the residuals become too high. For the user it is probably
nicer to have a hard error message that points to the cause of the
problem.