### PR TITLE
Make building of tests and tests-gtest conditional on --enable-testing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,4 @@
-SUBDIRS = include lib tests tests-gtest
+SUBDIRS = include lib
+if QPHIX_BUILD_TESTS
+SUBDIRS += tests tests-gtest
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ AC_ARG_ENABLE(parallel-arch,
 AC_ARG_ENABLE(testing,
    AC_HELP_STRING([--enable-testing],
    [ Build the tests (takes quite some time) ]),
-   [ build_tests=yes ],
+   [ build_tests=${enableval} ],
    [ build_tests=no ]
 )
 
@@ -524,6 +524,11 @@ yes|YES)
 ;;
 esac
 
+if test "x${build_tests}x" = "xyesx"; then
+  AC_MSG_NOTICE([Building tests])
+else
+  AC_MSG_NOTICE([Not building tests])
+fi
 AM_CONDITIONAL(QPHIX_BUILD_TESTS, [ test "${build_tests}" = "yes" ])
 
 AM_CONDITIONAL(QPHIX_BUILD_CLOVER, [ test "x${build_clover}x" = "xyesx" ])


### PR DESCRIPTION
@martin-ueding I think this is a simpler and more comprehensive way of disabling the building of tests. The problem is mainly that even the test framework requires QDP, so when building without QDP, even that fails...

When one wants to build and run tests, one would want to build all the checks against QDP anyway, I presume.