### PR TITLE
Explicitly instantiate the templates

### DIFF
--- a/include/qphix/clov_dslash_generated.h
+++ b/include/qphix/clov_dslash_generated.h
@@ -1,41 +1,48 @@
-// This file has been automatically generated. Do not change it manually, rather look
-// for the template in qphix-codegen.
+// This file has been automatically generated. Do not change it manually, rather look for the template in qphix-codegen.
 
 #pragma once
 
 #include "qphix/diagnostics.h"
 
-#if defined(QPHIX_AVX_SOURCE)
+
+
+#if defined (QPHIX_AVX_SOURCE)
 QPHIX_MESSAGE("including qphix/avx/clov_dslash_avx_complete_specialization.h")
 #include "qphix/avx/clov_dslash_avx_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_AVX2_SOURCE)
+
+#if defined (QPHIX_AVX2_SOURCE)
 QPHIX_MESSAGE("including qphix/avx2/clov_dslash_avx2_complete_specialization.h")
 #include "qphix/avx2/clov_dslash_avx2_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_AVX512_SOURCE)
+
+#if defined (QPHIX_AVX512_SOURCE)
 QPHIX_MESSAGE("including qphix/avx512/clov_dslash_avx512_complete_specialization.h")
 #include "qphix/avx512/clov_dslash_avx512_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_MIC_SOURCE)
+
+#if defined (QPHIX_MIC_SOURCE)
 QPHIX_MESSAGE("including qphix/mic/clov_dslash_mic_complete_specialization.h")
 #include "qphix/mic/clov_dslash_mic_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_QPX_SOURCE)
+
+#if defined (QPHIX_QPX_SOURCE)
 QPHIX_MESSAGE("including qphix/qpx/clov_dslash_qpx_complete_specialization.h")
 #include "qphix/qpx/clov_dslash_qpx_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_SCALAR_SOURCE)
+
+#if defined (QPHIX_SCALAR_SOURCE)
 QPHIX_MESSAGE("including qphix/scalar/clov_dslash_scalar_complete_specialization.h")
 #include "qphix/scalar/clov_dslash_scalar_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_SSE_SOURCE)
+
+#if defined (QPHIX_SSE_SOURCE)
 QPHIX_MESSAGE("including qphix/sse/clov_dslash_sse_complete_specialization.h")
 #include "qphix/sse/clov_dslash_sse_complete_specialization.h"
 #endif

--- a/include/qphix/clover_dslash_def.h
+++ b/include/qphix/clover_dslash_def.h
@@ -193,10 +193,5 @@ class ClovDslash
 }; // Class
 
 } // Namespace
-#include "qphix/clover_dslash_body.h"
-#ifdef QPHIX_DO_COMMS
-// Disable comms for nokw
-#include "qphix/clov_face.h"
-#endif
 
 #endif

--- a/include/qphix/dslash_def.h
+++ b/include/qphix/dslash_def.h
@@ -174,9 +174,4 @@ class Dslash
 }; // Class
 
 } // Namespace
-#include "qphix/dslash_body.h"
-
-#ifdef QPHIX_DO_COMMS
-#include "qphix/face.h"
-#endif
 #endif

--- a/include/qphix/dslash_generated.h
+++ b/include/qphix/dslash_generated.h
@@ -1,41 +1,48 @@
-// This file has been automatically generated. Do not change it manually, rather look
-// for the template in qphix-codegen.
+// This file has been automatically generated. Do not change it manually, rather look for the template in qphix-codegen.
 
 #pragma once
 
 #include "qphix/diagnostics.h"
 
-#if defined(QPHIX_AVX_SOURCE)
+
+
+#if defined (QPHIX_AVX_SOURCE)
 QPHIX_MESSAGE("including qphix/avx/dslash_avx_complete_specialization.h")
 #include "qphix/avx/dslash_avx_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_AVX2_SOURCE)
+
+#if defined (QPHIX_AVX2_SOURCE)
 QPHIX_MESSAGE("including qphix/avx2/dslash_avx2_complete_specialization.h")
 #include "qphix/avx2/dslash_avx2_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_AVX512_SOURCE)
+
+#if defined (QPHIX_AVX512_SOURCE)
 QPHIX_MESSAGE("including qphix/avx512/dslash_avx512_complete_specialization.h")
 #include "qphix/avx512/dslash_avx512_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_MIC_SOURCE)
+
+#if defined (QPHIX_MIC_SOURCE)
 QPHIX_MESSAGE("including qphix/mic/dslash_mic_complete_specialization.h")
 #include "qphix/mic/dslash_mic_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_QPX_SOURCE)
+
+#if defined (QPHIX_QPX_SOURCE)
 QPHIX_MESSAGE("including qphix/qpx/dslash_qpx_complete_specialization.h")
 #include "qphix/qpx/dslash_qpx_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_SCALAR_SOURCE)
+
+#if defined (QPHIX_SCALAR_SOURCE)
 QPHIX_MESSAGE("including qphix/scalar/dslash_scalar_complete_specialization.h")
 #include "qphix/scalar/dslash_scalar_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_SSE_SOURCE)
+
+#if defined (QPHIX_SSE_SOURCE)
 QPHIX_MESSAGE("including qphix/sse/dslash_sse_complete_specialization.h")
 #include "qphix/sse/dslash_sse_complete_specialization.h"
 #endif

--- a/include/qphix/tm_clov_dslash_def.h
+++ b/include/qphix/tm_clov_dslash_def.h
@@ -197,10 +197,4 @@ class TMClovDslash
 
 } // Namespace
 
-#include "qphix/tm_clov_dslash_body.h"
-
-#ifdef QPHIX_DO_COMMS
-#include "qphix/tm_clov_dslash_face.h"
-#endif
-
 #endif // Include guard

--- a/include/qphix/tm_clov_dslash_generated.h
+++ b/include/qphix/tm_clov_dslash_generated.h
@@ -1,43 +1,48 @@
-// This file has been automatically generated. Do not change it manually, rather look
-// for the template in qphix-codegen.
+// This file has been automatically generated. Do not change it manually, rather look for the template in qphix-codegen.
 
 #pragma once
 
 #include "qphix/diagnostics.h"
 
-#if defined(QPHIX_AVX_SOURCE)
+
+
+#if defined (QPHIX_AVX_SOURCE)
 QPHIX_MESSAGE("including qphix/avx/tm_clov_dslash_avx_complete_specialization.h")
 #include "qphix/avx/tm_clov_dslash_avx_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_AVX2_SOURCE)
+
+#if defined (QPHIX_AVX2_SOURCE)
 QPHIX_MESSAGE("including qphix/avx2/tm_clov_dslash_avx2_complete_specialization.h")
 #include "qphix/avx2/tm_clov_dslash_avx2_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_AVX512_SOURCE)
-QPHIX_MESSAGE(
-    "including qphix/avx512/tm_clov_dslash_avx512_complete_specialization.h")
+
+#if defined (QPHIX_AVX512_SOURCE)
+QPHIX_MESSAGE("including qphix/avx512/tm_clov_dslash_avx512_complete_specialization.h")
 #include "qphix/avx512/tm_clov_dslash_avx512_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_MIC_SOURCE)
+
+#if defined (QPHIX_MIC_SOURCE)
 QPHIX_MESSAGE("including qphix/mic/tm_clov_dslash_mic_complete_specialization.h")
 #include "qphix/mic/tm_clov_dslash_mic_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_QPX_SOURCE)
+
+#if defined (QPHIX_QPX_SOURCE)
 QPHIX_MESSAGE("including qphix/qpx/tm_clov_dslash_qpx_complete_specialization.h")
 #include "qphix/qpx/tm_clov_dslash_qpx_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_SCALAR_SOURCE)
-QPHIX_MESSAGE(
-    "including qphix/scalar/tm_clov_dslash_scalar_complete_specialization.h")
+
+#if defined (QPHIX_SCALAR_SOURCE)
+QPHIX_MESSAGE("including qphix/scalar/tm_clov_dslash_scalar_complete_specialization.h")
 #include "qphix/scalar/tm_clov_dslash_scalar_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_SSE_SOURCE)
+
+#if defined (QPHIX_SSE_SOURCE)
 QPHIX_MESSAGE("including qphix/sse/tm_clov_dslash_sse_complete_specialization.h")
 #include "qphix/sse/tm_clov_dslash_sse_complete_specialization.h"
 #endif

--- a/include/qphix/tm_dslash_def.h
+++ b/include/qphix/tm_dslash_def.h
@@ -188,9 +188,5 @@ class TMDslash
 }; // Class
 
 } // Namespace
-#include "qphix/tm_dslash_body.h"
 
-#ifdef QPHIX_QMP_COMMS
-#include "qphix/tm_dslash_face.h"
-#endif
 #endif

--- a/include/qphix/tm_dslash_generated.h
+++ b/include/qphix/tm_dslash_generated.h
@@ -1,41 +1,48 @@
-// This file has been automatically generated. Do not change it manually, rather look
-// for the template in qphix-codegen.
+// This file has been automatically generated. Do not change it manually, rather look for the template in qphix-codegen.
 
 #pragma once
 
 #include "qphix/diagnostics.h"
 
-#if defined(QPHIX_AVX_SOURCE)
+
+
+#if defined (QPHIX_AVX_SOURCE)
 QPHIX_MESSAGE("including qphix/avx/tm_dslash_avx_complete_specialization.h")
 #include "qphix/avx/tm_dslash_avx_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_AVX2_SOURCE)
+
+#if defined (QPHIX_AVX2_SOURCE)
 QPHIX_MESSAGE("including qphix/avx2/tm_dslash_avx2_complete_specialization.h")
 #include "qphix/avx2/tm_dslash_avx2_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_AVX512_SOURCE)
+
+#if defined (QPHIX_AVX512_SOURCE)
 QPHIX_MESSAGE("including qphix/avx512/tm_dslash_avx512_complete_specialization.h")
 #include "qphix/avx512/tm_dslash_avx512_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_MIC_SOURCE)
+
+#if defined (QPHIX_MIC_SOURCE)
 QPHIX_MESSAGE("including qphix/mic/tm_dslash_mic_complete_specialization.h")
 #include "qphix/mic/tm_dslash_mic_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_QPX_SOURCE)
+
+#if defined (QPHIX_QPX_SOURCE)
 QPHIX_MESSAGE("including qphix/qpx/tm_dslash_qpx_complete_specialization.h")
 #include "qphix/qpx/tm_dslash_qpx_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_SCALAR_SOURCE)
+
+#if defined (QPHIX_SCALAR_SOURCE)
 QPHIX_MESSAGE("including qphix/scalar/tm_dslash_scalar_complete_specialization.h")
 #include "qphix/scalar/tm_dslash_scalar_complete_specialization.h"
 #endif
 
-#if defined(QPHIX_SSE_SOURCE)
+
+#if defined (QPHIX_SSE_SOURCE)
 QPHIX_MESSAGE("including qphix/sse/tm_dslash_sse_complete_specialization.h")
 #include "qphix/sse/tm_dslash_sse_complete_specialization.h"
 #endif

--- a/lib/ClovDslash_instantiation.cpp
+++ b/lib/ClovDslash_instantiation.cpp
@@ -1,0 +1,98 @@
+// This file has been automatically generated. Do not change it manually, rather look for the template in qphix-codegen.
+
+#include "qphix/clover_dslash_def.h"
+
+#include "qphix/clover_dslash_body.h"
+
+#ifdef QPHIX_DO_COMMS
+// Disable comms for nokw
+#include "qphix/face.h"
+#endif
+
+namespace QPhiX {
+
+
+#if defined (QPHIX_AVX_SOURCE)
+template class ClovDslash<double, 4, 2, true>;
+template class ClovDslash<double, 4, 2, false>;
+template class ClovDslash<double, 4, 4, true>;
+template class ClovDslash<double, 4, 4, false>;
+template class ClovDslash<float, 8, 4, true>;
+template class ClovDslash<float, 8, 4, false>;
+template class ClovDslash<float, 8, 8, true>;
+template class ClovDslash<float, 8, 8, false>;
+#endif
+
+#if defined (QPHIX_AVX2_SOURCE)
+template class ClovDslash<double, 4, 2, true>;
+template class ClovDslash<double, 4, 2, false>;
+template class ClovDslash<double, 4, 4, true>;
+template class ClovDslash<double, 4, 4, false>;
+template class ClovDslash<float, 8, 4, true>;
+template class ClovDslash<float, 8, 4, false>;
+template class ClovDslash<float, 8, 8, true>;
+template class ClovDslash<float, 8, 8, false>;
+template class ClovDslash<half, 8, 4, true>;
+template class ClovDslash<half, 8, 4, false>;
+template class ClovDslash<half, 8, 8, true>;
+template class ClovDslash<half, 8, 8, false>;
+#endif
+
+#if defined (QPHIX_AVX512_SOURCE)
+template class ClovDslash<double, 8, 4, true>;
+template class ClovDslash<double, 8, 4, false>;
+template class ClovDslash<double, 8, 8, true>;
+template class ClovDslash<double, 8, 8, false>;
+template class ClovDslash<float, 16, 4, true>;
+template class ClovDslash<float, 16, 4, false>;
+template class ClovDslash<float, 16, 8, true>;
+template class ClovDslash<float, 16, 8, false>;
+template class ClovDslash<float, 16, 16, true>;
+template class ClovDslash<float, 16, 16, false>;
+template class ClovDslash<half, 16, 4, true>;
+template class ClovDslash<half, 16, 4, false>;
+template class ClovDslash<half, 16, 8, true>;
+template class ClovDslash<half, 16, 8, false>;
+template class ClovDslash<half, 16, 16, true>;
+template class ClovDslash<half, 16, 16, false>;
+#endif
+
+#if defined (QPHIX_MIC_SOURCE)
+template class ClovDslash<double, 8, 4, true>;
+template class ClovDslash<double, 8, 4, false>;
+template class ClovDslash<double, 8, 8, true>;
+template class ClovDslash<double, 8, 8, false>;
+template class ClovDslash<float, 16, 4, true>;
+template class ClovDslash<float, 16, 4, false>;
+template class ClovDslash<float, 16, 8, true>;
+template class ClovDslash<float, 16, 8, false>;
+template class ClovDslash<float, 16, 16, true>;
+template class ClovDslash<float, 16, 16, false>;
+template class ClovDslash<half, 16, 4, true>;
+template class ClovDslash<half, 16, 4, false>;
+template class ClovDslash<half, 16, 8, true>;
+template class ClovDslash<half, 16, 8, false>;
+template class ClovDslash<half, 16, 16, true>;
+template class ClovDslash<half, 16, 16, false>;
+#endif
+
+#if defined (QPHIX_QPX_SOURCE)
+template class ClovDslash<double, 4, 4, true>;
+template class ClovDslash<double, 4, 4, false>;
+#endif
+
+#if defined (QPHIX_SCALAR_SOURCE)
+template class ClovDslash<double, 1, 1, true>;
+template class ClovDslash<double, 1, 1, false>;
+template class ClovDslash<float, 1, 1, true>;
+template class ClovDslash<float, 1, 1, false>;
+#endif
+
+#if defined (QPHIX_SSE_SOURCE)
+template class ClovDslash<double, 2, 2, true>;
+template class ClovDslash<double, 2, 2, false>;
+template class ClovDslash<float, 4, 4, true>;
+template class ClovDslash<float, 4, 4, false>;
+#endif
+
+}

--- a/lib/Dslash_instantiation.cpp
+++ b/lib/Dslash_instantiation.cpp
@@ -1,0 +1,98 @@
+// This file has been automatically generated. Do not change it manually, rather look for the template in qphix-codegen.
+
+#include "qphix/dslash_def.h"
+
+#include "qphix/dslash_body.h"
+
+#ifdef QPHIX_DO_COMMS
+// Disable comms for nokw
+#include "qphix/clov_face.h"
+#endif
+
+namespace QPhiX {
+
+
+#if defined (QPHIX_AVX_SOURCE)
+template class Dslash<double, 4, 2, true>;
+template class Dslash<double, 4, 2, false>;
+template class Dslash<double, 4, 4, true>;
+template class Dslash<double, 4, 4, false>;
+template class Dslash<float, 8, 4, true>;
+template class Dslash<float, 8, 4, false>;
+template class Dslash<float, 8, 8, true>;
+template class Dslash<float, 8, 8, false>;
+#endif
+
+#if defined (QPHIX_AVX2_SOURCE)
+template class Dslash<double, 4, 2, true>;
+template class Dslash<double, 4, 2, false>;
+template class Dslash<double, 4, 4, true>;
+template class Dslash<double, 4, 4, false>;
+template class Dslash<float, 8, 4, true>;
+template class Dslash<float, 8, 4, false>;
+template class Dslash<float, 8, 8, true>;
+template class Dslash<float, 8, 8, false>;
+template class Dslash<half, 8, 4, true>;
+template class Dslash<half, 8, 4, false>;
+template class Dslash<half, 8, 8, true>;
+template class Dslash<half, 8, 8, false>;
+#endif
+
+#if defined (QPHIX_AVX512_SOURCE)
+template class Dslash<double, 8, 4, true>;
+template class Dslash<double, 8, 4, false>;
+template class Dslash<double, 8, 8, true>;
+template class Dslash<double, 8, 8, false>;
+template class Dslash<float, 16, 4, true>;
+template class Dslash<float, 16, 4, false>;
+template class Dslash<float, 16, 8, true>;
+template class Dslash<float, 16, 8, false>;
+template class Dslash<float, 16, 16, true>;
+template class Dslash<float, 16, 16, false>;
+template class Dslash<half, 16, 4, true>;
+template class Dslash<half, 16, 4, false>;
+template class Dslash<half, 16, 8, true>;
+template class Dslash<half, 16, 8, false>;
+template class Dslash<half, 16, 16, true>;
+template class Dslash<half, 16, 16, false>;
+#endif
+
+#if defined (QPHIX_MIC_SOURCE)
+template class Dslash<double, 8, 4, true>;
+template class Dslash<double, 8, 4, false>;
+template class Dslash<double, 8, 8, true>;
+template class Dslash<double, 8, 8, false>;
+template class Dslash<float, 16, 4, true>;
+template class Dslash<float, 16, 4, false>;
+template class Dslash<float, 16, 8, true>;
+template class Dslash<float, 16, 8, false>;
+template class Dslash<float, 16, 16, true>;
+template class Dslash<float, 16, 16, false>;
+template class Dslash<half, 16, 4, true>;
+template class Dslash<half, 16, 4, false>;
+template class Dslash<half, 16, 8, true>;
+template class Dslash<half, 16, 8, false>;
+template class Dslash<half, 16, 16, true>;
+template class Dslash<half, 16, 16, false>;
+#endif
+
+#if defined (QPHIX_QPX_SOURCE)
+template class Dslash<double, 4, 4, true>;
+template class Dslash<double, 4, 4, false>;
+#endif
+
+#if defined (QPHIX_SCALAR_SOURCE)
+template class Dslash<double, 1, 1, true>;
+template class Dslash<double, 1, 1, false>;
+template class Dslash<float, 1, 1, true>;
+template class Dslash<float, 1, 1, false>;
+#endif
+
+#if defined (QPHIX_SSE_SOURCE)
+template class Dslash<double, 2, 2, true>;
+template class Dslash<double, 2, 2, false>;
+template class Dslash<float, 4, 4, true>;
+template class Dslash<float, 4, 4, false>;
+#endif
+
+}

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -14,3 +14,22 @@ libqphix_solver_a_SOURCES += bgq_threadbind.cc
 else
 libqphix_solver_a_SOURCES += generic_threadbind.cc
 endif
+
+
+###############################################################################
+#                      Explicit Template Instantiations                       #
+###############################################################################
+
+libqphix_solver_a_SOURCES += Dslash_instantiation.cpp
+
+if QPHIX_BUILD_CLOVER
+libqphix_solver_a_SOURCES += ClovDslash_instantiation.cpp
+endif
+
+if QPHIX_BUILD_TWISTED_MASS
+libqphix_solver_a_SOURCES += TMDslash_instantiation.cpp
+endif
+
+if QPHIX_BUILD_TWISTED_MASS_WITH_CLOVER
+libqphix_solver_a_SOURCES += TMClovDslash_instantiation.cpp
+endif

--- a/lib/TMClovDslash_instantiation.cpp
+++ b/lib/TMClovDslash_instantiation.cpp
@@ -1,0 +1,98 @@
+// This file has been automatically generated. Do not change it manually, rather look for the template in qphix-codegen.
+
+#include "qphix/tm_clov_dslash_def.h"
+
+#include "qphix/tm_clov_dslash_body.h"
+
+#ifdef QPHIX_DO_COMMS
+// Disable comms for nokw
+#include "qphix/tm_dslash_face.h"
+#endif
+
+namespace QPhiX {
+
+
+#if defined (QPHIX_AVX_SOURCE)
+template class TMClovDslash<double, 4, 2, true>;
+template class TMClovDslash<double, 4, 2, false>;
+template class TMClovDslash<double, 4, 4, true>;
+template class TMClovDslash<double, 4, 4, false>;
+template class TMClovDslash<float, 8, 4, true>;
+template class TMClovDslash<float, 8, 4, false>;
+template class TMClovDslash<float, 8, 8, true>;
+template class TMClovDslash<float, 8, 8, false>;
+#endif
+
+#if defined (QPHIX_AVX2_SOURCE)
+template class TMClovDslash<double, 4, 2, true>;
+template class TMClovDslash<double, 4, 2, false>;
+template class TMClovDslash<double, 4, 4, true>;
+template class TMClovDslash<double, 4, 4, false>;
+template class TMClovDslash<float, 8, 4, true>;
+template class TMClovDslash<float, 8, 4, false>;
+template class TMClovDslash<float, 8, 8, true>;
+template class TMClovDslash<float, 8, 8, false>;
+template class TMClovDslash<half, 8, 4, true>;
+template class TMClovDslash<half, 8, 4, false>;
+template class TMClovDslash<half, 8, 8, true>;
+template class TMClovDslash<half, 8, 8, false>;
+#endif
+
+#if defined (QPHIX_AVX512_SOURCE)
+template class TMClovDslash<double, 8, 4, true>;
+template class TMClovDslash<double, 8, 4, false>;
+template class TMClovDslash<double, 8, 8, true>;
+template class TMClovDslash<double, 8, 8, false>;
+template class TMClovDslash<float, 16, 4, true>;
+template class TMClovDslash<float, 16, 4, false>;
+template class TMClovDslash<float, 16, 8, true>;
+template class TMClovDslash<float, 16, 8, false>;
+template class TMClovDslash<float, 16, 16, true>;
+template class TMClovDslash<float, 16, 16, false>;
+template class TMClovDslash<half, 16, 4, true>;
+template class TMClovDslash<half, 16, 4, false>;
+template class TMClovDslash<half, 16, 8, true>;
+template class TMClovDslash<half, 16, 8, false>;
+template class TMClovDslash<half, 16, 16, true>;
+template class TMClovDslash<half, 16, 16, false>;
+#endif
+
+#if defined (QPHIX_MIC_SOURCE)
+template class TMClovDslash<double, 8, 4, true>;
+template class TMClovDslash<double, 8, 4, false>;
+template class TMClovDslash<double, 8, 8, true>;
+template class TMClovDslash<double, 8, 8, false>;
+template class TMClovDslash<float, 16, 4, true>;
+template class TMClovDslash<float, 16, 4, false>;
+template class TMClovDslash<float, 16, 8, true>;
+template class TMClovDslash<float, 16, 8, false>;
+template class TMClovDslash<float, 16, 16, true>;
+template class TMClovDslash<float, 16, 16, false>;
+template class TMClovDslash<half, 16, 4, true>;
+template class TMClovDslash<half, 16, 4, false>;
+template class TMClovDslash<half, 16, 8, true>;
+template class TMClovDslash<half, 16, 8, false>;
+template class TMClovDslash<half, 16, 16, true>;
+template class TMClovDslash<half, 16, 16, false>;
+#endif
+
+#if defined (QPHIX_QPX_SOURCE)
+template class TMClovDslash<double, 4, 4, true>;
+template class TMClovDslash<double, 4, 4, false>;
+#endif
+
+#if defined (QPHIX_SCALAR_SOURCE)
+template class TMClovDslash<double, 1, 1, true>;
+template class TMClovDslash<double, 1, 1, false>;
+template class TMClovDslash<float, 1, 1, true>;
+template class TMClovDslash<float, 1, 1, false>;
+#endif
+
+#if defined (QPHIX_SSE_SOURCE)
+template class TMClovDslash<double, 2, 2, true>;
+template class TMClovDslash<double, 2, 2, false>;
+template class TMClovDslash<float, 4, 4, true>;
+template class TMClovDslash<float, 4, 4, false>;
+#endif
+
+}

--- a/lib/TMDslash_instantiation.cpp
+++ b/lib/TMDslash_instantiation.cpp
@@ -1,0 +1,98 @@
+// This file has been automatically generated. Do not change it manually, rather look for the template in qphix-codegen.
+
+#include "qphix/tm_dslash_def.h"
+
+#include "qphix/tm_dslash_body.h"
+
+#ifdef QPHIX_DO_COMMS
+// Disable comms for nokw
+#include "qphix/tm_clov_dslash_face.h"
+#endif
+
+namespace QPhiX {
+
+
+#if defined (QPHIX_AVX_SOURCE)
+template class TMDslash<double, 4, 2, true>;
+template class TMDslash<double, 4, 2, false>;
+template class TMDslash<double, 4, 4, true>;
+template class TMDslash<double, 4, 4, false>;
+template class TMDslash<float, 8, 4, true>;
+template class TMDslash<float, 8, 4, false>;
+template class TMDslash<float, 8, 8, true>;
+template class TMDslash<float, 8, 8, false>;
+#endif
+
+#if defined (QPHIX_AVX2_SOURCE)
+template class TMDslash<double, 4, 2, true>;
+template class TMDslash<double, 4, 2, false>;
+template class TMDslash<double, 4, 4, true>;
+template class TMDslash<double, 4, 4, false>;
+template class TMDslash<float, 8, 4, true>;
+template class TMDslash<float, 8, 4, false>;
+template class TMDslash<float, 8, 8, true>;
+template class TMDslash<float, 8, 8, false>;
+template class TMDslash<half, 8, 4, true>;
+template class TMDslash<half, 8, 4, false>;
+template class TMDslash<half, 8, 8, true>;
+template class TMDslash<half, 8, 8, false>;
+#endif
+
+#if defined (QPHIX_AVX512_SOURCE)
+template class TMDslash<double, 8, 4, true>;
+template class TMDslash<double, 8, 4, false>;
+template class TMDslash<double, 8, 8, true>;
+template class TMDslash<double, 8, 8, false>;
+template class TMDslash<float, 16, 4, true>;
+template class TMDslash<float, 16, 4, false>;
+template class TMDslash<float, 16, 8, true>;
+template class TMDslash<float, 16, 8, false>;
+template class TMDslash<float, 16, 16, true>;
+template class TMDslash<float, 16, 16, false>;
+template class TMDslash<half, 16, 4, true>;
+template class TMDslash<half, 16, 4, false>;
+template class TMDslash<half, 16, 8, true>;
+template class TMDslash<half, 16, 8, false>;
+template class TMDslash<half, 16, 16, true>;
+template class TMDslash<half, 16, 16, false>;
+#endif
+
+#if defined (QPHIX_MIC_SOURCE)
+template class TMDslash<double, 8, 4, true>;
+template class TMDslash<double, 8, 4, false>;
+template class TMDslash<double, 8, 8, true>;
+template class TMDslash<double, 8, 8, false>;
+template class TMDslash<float, 16, 4, true>;
+template class TMDslash<float, 16, 4, false>;
+template class TMDslash<float, 16, 8, true>;
+template class TMDslash<float, 16, 8, false>;
+template class TMDslash<float, 16, 16, true>;
+template class TMDslash<float, 16, 16, false>;
+template class TMDslash<half, 16, 4, true>;
+template class TMDslash<half, 16, 4, false>;
+template class TMDslash<half, 16, 8, true>;
+template class TMDslash<half, 16, 8, false>;
+template class TMDslash<half, 16, 16, true>;
+template class TMDslash<half, 16, 16, false>;
+#endif
+
+#if defined (QPHIX_QPX_SOURCE)
+template class TMDslash<double, 4, 4, true>;
+template class TMDslash<double, 4, 4, false>;
+#endif
+
+#if defined (QPHIX_SCALAR_SOURCE)
+template class TMDslash<double, 1, 1, true>;
+template class TMDslash<double, 1, 1, false>;
+template class TMDslash<float, 1, 1, true>;
+template class TMDslash<float, 1, 1, false>;
+#endif
+
+#if defined (QPHIX_SSE_SOURCE)
+template class TMDslash<double, 2, 2, true>;
+template class TMDslash<double, 2, 2, false>;
+template class TMDslash<float, 4, 4, true>;
+template class TMDslash<float, 4, 4, false>;
+#endif
+
+}

--- a/tests/testTWMDslashFull.cc
+++ b/tests/testTWMDslashFull.cc
@@ -94,6 +94,7 @@ void testTWMDslashFull::run(void)
       u_in[mu] = u[mu];
     }
 
+#if defined(QPHIX_SCALAR_SOURCE)
     if (soalen == 1) {
       QDPIO::cout << "VECLEN = " << VECLEN_SP << ", SOALEN = 4" << endl;
       testTWMDslashWrapper<float, VECLEN_SP, 1, UF, PhiF>();
@@ -102,6 +103,7 @@ void testTWMDslashFull::run(void)
       testTWMCGWrapper<float, VECLEN_SP, 1, UF, PhiF>();
       testTWMBiCGStabWrapper<float, VECLEN_SP, 1, MUF, PhiF>(u_in);
     }
+#endif
 
     if (soalen == 4) {
       QDPIO::cout << "VECLEN = " << VECLEN_SP << ", SOALEN = 4" << endl;


### PR DESCRIPTION
I have created explicit template instantiations for all the kernels. This should speed up incremental build time significantly. The code should just `#include` the `_def.h` version and link to `libqphix_solver.a`.

Could you (@bjoo, @kostrzewa) please take a look at this, perhaps even try to compile it on your machine to see whether I have not missed anything?