### PR TITLE
InvRichardsonMultiPrec: add support for CG as the inner solver

### DIFF
--- a/include/qphix/inv_richardson_multiprec.h
+++ b/include/qphix/inv_richardson_multiprec.h
@@ -249,9 +249,13 @@ class InvRichardsonMultiPrec
       r_inner[f] = (SpinorInner *)geom_inner.allocCBFourSpinor();
     for (uint8_t f = 0; f < num_flav; ++f)
       dx_inner[f] = (SpinorInner *)geom_inner.allocCBFourSpinor();
-    if( MdagM ){
-      for (uint8_t f = 0; f < num_flav; ++f)
-        tmp_MdagM[f] = (Spinor *)geom.allocCBFourSpinor();
+      for (uint8_t f = 0; f < num_flav; ++f){
+        if( MdagM ){
+          tmp_MdagM[f] = (Spinor *)geom.allocCBFourSpinor();
+        } else {
+          tmp_MdagM[f] = nullptr;
+        }
+      }
     }
 
     // Initial value for norm2threads. Use all threads

--- a/include/qphix/inv_richardson_multiprec.h
+++ b/include/qphix/inv_richardson_multiprec.h
@@ -249,12 +249,11 @@ class InvRichardsonMultiPrec
       r_inner[f] = (SpinorInner *)geom_inner.allocCBFourSpinor();
     for (uint8_t f = 0; f < num_flav; ++f)
       dx_inner[f] = (SpinorInner *)geom_inner.allocCBFourSpinor();
-      for (uint8_t f = 0; f < num_flav; ++f){
-        if( MdagM ){
-          tmp_MdagM[f] = (Spinor *)geom.allocCBFourSpinor();
-        } else {
-          tmp_MdagM[f] = nullptr;
-        }
+    for (uint8_t f = 0; f < num_flav; ++f){
+      if( MdagM ){
+        tmp_MdagM[f] = (Spinor *)geom.allocCBFourSpinor();
+      } else {
+        tmp_MdagM[f] = nullptr;
       }
     }
 


### PR DESCRIPTION
by adding a new template argument MdagM, which will cause the correct operator to be applied in the updates

This is unfortunately not transparent unless we go ahead and add MdagM linear operators which would serve as m_outer here.