### PR TITLE
complete generalization of inv_richardson_multiprec to multiple flavours

### DIFF
--- a/include/qphix/inv_richardson_multiprec.h
+++ b/include/qphix/inv_richardson_multiprec.h
@@ -206,8 +206,8 @@ class InvRichardsonMultiPrec
   }
 
   InvRichardsonMultiPrec(
-      EvenOddLinearOperator<FT, V, S, Compress> &m_outer_,
-      AbstractSolver<FTInner, VInner, SInner, CompressInner> &solver_inner_,
+      EvenOddLinearOperatorBase &m_outer_,
+      AbstractSolver<FTInner, VInner, SInner, CompressInner, EvenOddLinearOperatorBase::num_flav > &solver_inner_,
       const double delta_,
       const int max_iters_)
       : m_outer(m_outer_), solver_inner(solver_inner_), delta(delta_),


### PR DESCRIPTION
This is a follow-up to dab5f69768a66603c60fb7308dc1c9e63cb6569a which should complete the generalisation of the mixed solver to multiple flavours.