### PR TITLE
Fix recursive j n

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ option(mpi_comms "Use plain MPI comms instead of QMP in the kernels" ON)
 # Codegen stuff
 set(host_cxx ${CMAKE_CXX_COMPILER} CACHE STRING "select target CXX Compiler for building libqphix-codegen.a" )
 set(host_cxxflags ${CMAKE_CXX_FLAGS} CACHE STRING  "select target CXXFLAGS for building libqphix-codege.a")
-set(recursive_jN '' CACHE STRING "select -j value for recursive make (defaults to 1)")
+set(recursive_jN 1 CACHE STRING "select -j value for recursive make (defaults to 1)")
 option(skip_build "Developer only: Reduce building of certain kernels for faster build" OFF)
 
 ###############################################################################


### PR DESCRIPTION
The typo that I corrected in the last round actually leads to issues: when nothing is specified for `recursive_jN`, make simply goes mental and spawns hundreds of processes (we had trouble with our CI as a result ... ) I've defaulted to 1 for safety.