### PR TITLE
Use size_t for call to aligned_malloc

### DIFF
--- a/include/qphix/dslash_utils.h
+++ b/include/qphix/dslash_utils.h
@@ -66,7 +66,7 @@ struct BlockPhase {
   int cid_yz;
 };
 
-inline void *aligned_malloc(int size, int alignment)
+inline void *aligned_malloc(size_t size, int alignment)
 {
   void *v;
   int ok;


### PR DESCRIPTION
If using the POSIX memory allocator (rather than `_mm_malloc`), the code originally accepted an `int` to store the size of the allocation, which fails if the allocation size exceeds about 2 GB.  (Empirically, this caused problems for me when allocating a $48^3 \times 96$ gauge field.)  Changing this to type `size_t`, as is done in the analogous version using `_mm_malloc`, allows much larger memory allocations, including my test $48^3$ field.